### PR TITLE
Provisions box using packer and Atlas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .vagrant
 .bowerrc
 
+# Packer
+packer_*
+
 # Continuous integration reports
 /build/*
 !/build/.gitignore

--- a/app/Resources/doc/20-packaging.md
+++ b/app/Resources/doc/20-packaging.md
@@ -1,6 +1,14 @@
 # Packaging
 
-Login to [atlas.hashicorp.com](http://atlas.hashicorp.com) after having creating an account and   
+New versions of a configuration template and the application can be pushed manually using `Packer` and `Vagrant`.
+New builds are started automatically via web hook and GitHub integration with Atlas.
+
+The results of these manual and automated pushes are Atlas artifacts (vagrant boxes) publicly available from
+[https://atlas.hashicorp.com/weaving-the-web/boxes/devobs-development](https://atlas.hashicorp.com/weaving-the-web/boxes/devobs-development)
+
+## Build configuration
+
+Login to [atlas.hashicorp.com](http://atlas.hashicorp.com) after having created an account and   
 start the [tutorial to package a vagrant box for distribution](https://atlas.hashicorp.com/tutorial/packer-vagrant)
 using `Packer`.
 
@@ -22,10 +30,20 @@ curl "https://atlas.hashicorp.com/ui/tutorial/check?access_token=$ATLAS_TOKEN"
 
 Provide the build name in the next step of the tutorial: `devobs-development`
 
-Push Packer template to Atlas
+Push configuration template and supporting files to Atlas by using Packer
 
 ```
 cd provisioning/packaging
 export ATLAS_USERNAME='Your Atlas username'
-packer push -name $ATLAS_USERNAME/devobs-development template.json
+export ATLAS_NAME='devobs-development'
+export ATLAS_SLUG=$ATLAS_USERNAME/$ATLAS_NAME
+packer push -name $ATLAS_SLUG template.json
+```
+
+## Application
+
+Push a new version of the application to Atlas by using Vagrant
+
+```
+vagrant push atlas
 ```

--- a/provisioning/ansible.txt
+++ b/provisioning/ansible.txt
@@ -3,7 +3,6 @@ ecdsa==0.13
 Jinja2==2.8
 MarkupSafe==0.23
 paramiko==1.16.0
-pycharm===debug
 pycrypto==2.6.1
 PyYAML==3.11
 wheel==0.24.0

--- a/provisioning/packaging/scripts/cleanup.sh
+++ b/provisioning/packaging/scripts/cleanup.sh
@@ -6,7 +6,6 @@ rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 echo "cleaning up udev rules"
-rm /etc/udev/rules.d/70-persistent-net.rules
 mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules

--- a/provisioning/packaging/scripts/clone-project.sh
+++ b/provisioning/packaging/scripts/clone-project.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-git clone https://github.com/WeavingTheWeb/devobs ~vagrant/devobs

--- a/provisioning/packaging/scripts/dep.sh
+++ b/provisioning/packaging/scripts/dep.sh
@@ -1,9 +1,32 @@
 #!/bin/bash
-#
-# Setup the the box. This runs as root
 
+# Setup the the box. This runs as root
 apt-get -y update
 
-apt-get -y install curl
+apt-get -y install \
+curl \
+libyaml-dev \
+python-dev \
+python-virtualenv
 
-# You can install anything you need here.
+cat > ~vagrant/ansible.txt <<DEPENDENCIES
+ansible==1.9.4
+ecdsa==0.13
+Jinja2==2.8
+MarkupSafe==0.23
+paramiko==1.16.0
+pycrypto==2.6.1
+PyYAML==3.11
+wheel==0.24.0
+DEPENDENCIES
+
+# Download dependencies
+pip install -r ~vagrant/ansible.txt
+
+mkdir -p /tmp/packer-provisioner-ansible-local
+
+mkdir -p /tmp/packer-provisioner-ansible-local/vars
+
+chmod 777 /tmp/packer-provisioner-ansible-local
+
+chmod 777 /tmp/packer-provisioner-ansible-local/vars

--- a/provisioning/packaging/template.json
+++ b/provisioning/packaging/template.json
@@ -4,6 +4,7 @@
       "vcs": true
     },
     "variables": {
+        "atlas_application_version": "{{env `ATLAS_BUILD_CONFIGURATION_VERSION`}}",
         "atlas_username": "{{env `ATLAS_USERNAME`}}",
         "atlas_name": "{{env `ATLAS_NAME`}}"
     },
@@ -16,7 +17,6 @@
                 "provisioning/packaging/scripts/vmware.sh",
                 "provisioning/packaging/scripts/vagrant.sh",
                 "provisioning/packaging/scripts/dep.sh",
-                "provisioning/packaging/scripts/clone-project.sh",
                 "provisioning/packaging/scripts/fix-no-tty.sh",
                 "provisioning/packaging/scripts/ensure-required-files-exist.sh",
                 "provisioning/packaging/scripts/cleanup.sh",
@@ -97,29 +97,31 @@
         }
     ],
     "post-processors": [
-        [{
-            "type": "vagrant",
-            "keep_input_artifact": false
-        },
-        {
-            "type": "atlas",
-            "only": ["vmware-iso"],
-            "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
-            "artifact_type": "vagrant.box",
-            "metadata": {
-                "provider": "vmware_desktop",
-                "version": "0.0.1"
+        [
+            {
+                "type": "vagrant",
+                "keep_input_artifact": false
+            },
+            {
+                "type": "atlas",
+                "only": ["vmware-iso"],
+                "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
+                "artifact_type": "vagrant.box",
+                "metadata": {
+                    "provider": "vmware_desktop",
+                    "version": "0.0.{{user `atlas_application_version`}}"
+                }
+            },
+            {
+                "type": "atlas",
+                "only": ["virtualbox-iso"],
+                "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
+                "artifact_type": "vagrant.box",
+                "metadata": {
+                    "provider": "virtualbox",
+                    "version": "0.0.{{user `atlas_application_version`}}"
+                }
             }
-        },
-        {
-            "type": "atlas",
-            "only": ["virtualbox-iso"],
-            "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
-            "artifact_type": "vagrant.box",
-            "metadata": {
-                "provider": "virtualbox",
-                "version": "0.0.1"
-            }
-        }]
+        ]
     ]
 }

--- a/provisioning/roles/server/tasks/main.yml
+++ b/provisioning/roles/server/tasks/main.yml
@@ -7,6 +7,7 @@
   sudo: yes
   apt: pkg={{ item }} state=latest
   with_items:
+    - acl
     - curl
     - wget
     - python-software-properties


### PR DESCRIPTION
Updates box name in Vagrantfile
    Setting MANUAL_PROVISION value environment variable to 1
    would trigger provisioning as handled by Packer and Atlas
Removes clone project script from build template
Prevents removal of persistent net rules
Installs Ansible beforing running playbook
Installs Ansible from dependencies in vagrant directory
Installs Ansible using aptitude
    See also https://github.com/hyperfocus1337/packer-virtualbox-atlas-template
Installs latest version of Ansible
Removes uneeded repository addition
Installs libyaml
Removes use of a virtualenv
Adds documentation about application pushes
Provisions acl package using aptitude
Attempts to bump versions automatically