### PR TITLE
Disable installation of PHP vendors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -69,7 +69,6 @@ dependencies:
     - npm install
     - npm install -g bower
     - /bin/bash -c 'source tests/.install-bower-components.sh'
-    - composer install --prefer-dist --no-interaction
   post:
     - wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
     - tar -xzf sc-latest-linux.tar.gz


### PR DESCRIPTION
Prevent CircleCi from installating vendors until tests are actually run with PHPUnit